### PR TITLE
Add socat as package

### DIFF
--- a/packer/http/centos-7.1/ks.cfg
+++ b/packer/http/centos-7.1/ks.cfg
@@ -54,6 +54,7 @@ net-tools
 bzip2
 docker-selinux
 rsync
+socat
 -NetworkManager
 -NetworkManager-team
 -NetworkManager-tui


### PR DESCRIPTION
This is required for OpenShift's 'oc port-forward' command.
